### PR TITLE
Upgrade dependencies and remove unused libs

### DIFF
--- a/USERS-GUIDE.md
+++ b/USERS-GUIDE.md
@@ -47,7 +47,9 @@ _Configuration_ is represented as an interface or abstract class optionally anno
 * Integrated with [Spring Framework](https://projects.spring.io/spring-framework) and
   and [Spring Boot](http://projects.spring.io/spring-boot).
 * High level _API_ for accessing configuration values.
-* Minimum set of dependencies: [SLF4J](http://slf4j.org) and [commons-lang](https://commons.apache.org/proper/commons-lang).
+* Minimum set of dependencies: [SLF4J](http://slf4j.org),
+  [commons-lang](https://commons.apache.org/proper/commons-lang) and
+  [commons-text](https://commons.apache.org/proper/commons-text).
 
 ## Getting Started
 

--- a/conf4j-ck/pom.xml
+++ b/conf4j-ck/pom.xml
@@ -64,11 +64,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>compile</scope>

--- a/conf4j-core/pom.xml
+++ b/conf4j-core/pom.xml
@@ -51,6 +51,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
         <!-- Test only dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -67,10 +71,6 @@
         <dependency>
             <groupId>org.apiguardian</groupId>
             <artifactId>apiguardian-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/CharacterConverter.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/CharacterConverter.java
@@ -29,8 +29,8 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeJava;
-import static org.apache.commons.lang3.StringEscapeUtils.unescapeJava;
+import static org.apache.commons.text.StringEscapeUtils.escapeJava;
+import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
 
 /**
  * This class converts {@link Character} to/from string.

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/DefaultTypeConverters.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/DefaultTypeConverters.java
@@ -103,6 +103,7 @@ public final class DefaultTypeConverters {
      * @param decoratingConverterFactories decorating converter factories.
      * @return composite converter.
      */
+    @SuppressWarnings("unchecked")
     public static TypeConverter<Object> createCompositeConverter(
             List<TypeConverter<?>> baseConverters,
             List<DecoratingConverterFactory> decoratingConverterFactories) {

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/JsonLikeConverter.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/JsonLikeConverter.java
@@ -37,8 +37,8 @@ import static com.sabre.oss.conf4j.converter.TypeConverterUtils.NOT_FOUND;
 import static com.sabre.oss.conf4j.converter.TypeConverterUtils.notEscapedIndexOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.commons.lang3.StringEscapeUtils.ESCAPE_JSON;
-import static org.apache.commons.lang3.StringEscapeUtils.UNESCAPE_JSON;
+import static org.apache.commons.text.StringEscapeUtils.ESCAPE_JSON;
+import static org.apache.commons.text.StringEscapeUtils.UNESCAPE_JAVA;
 
 /**
  * {@code JsonLikeConverter} is a {@link TypeConverter} that is able to parse and generate JSON-like representation
@@ -96,7 +96,7 @@ public class JsonLikeConverter implements TypeConverter<Object> {
     private static final String MSG_UNEXPECTED_EXTRA_DATA = "Object successfully constructed but not all characters have been consumed";
     private static final String MSG_UNEXPECTED_END_OF_DATA = "Unexpected end of string: %s";
 
-    private static final StringEscaper JSON_ESCAPER = new StringEscaper(ESCAPE_JSON::translate, UNESCAPE_JSON::translate);
+    private static final StringEscaper JSON_ESCAPER = new StringEscaper(ESCAPE_JSON::translate, UNESCAPE_JAVA::translate);
     private static final StringEscaper COMPACT_JSON_ESCAPER = new StringEscaper(ESCAPE_COMPACT_JSON::translate, UNESCAPE_COMPACT_JSON::translate);
 
     private final TypeConverter<Object> innerTypeConverter;
@@ -112,6 +112,7 @@ public class JsonLikeConverter implements TypeConverter<Object> {
         this(innerTypeConverter, true);
     }
 
+    @SuppressWarnings("unchecked")
     public JsonLikeConverter(TypeConverter<?> innerTypeConverter, boolean compactMode) {
         this.innerTypeConverter = (TypeConverter<Object>) requireNonNull(innerTypeConverter, "innerTypeConverter must not be null");
         this.defaultCompactMode = compactMode;

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/JsonLikeEscapeUtils.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/JsonLikeEscapeUtils.java
@@ -24,7 +24,12 @@
 
 package com.sabre.oss.conf4j.converter;
 
-import org.apache.commons.lang3.text.translate.*;
+import org.apache.commons.text.translate.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
 
 final class JsonLikeEscapeUtils {
     static final char COMMA = ',';
@@ -38,24 +43,29 @@ final class JsonLikeEscapeUtils {
     private JsonLikeEscapeUtils() {
     }
 
-    static final String[][] COMPACT_JSON_STRING_ESCAPE = {
-            {"\\", "\\\\"},
-            {"/", "\\/"},
-            {"" + COMMA, "\\" + COMMA},
-            {"" + COLON, "\\" + COLON},
-            {"" + RIGHT_CURLY_BRACE, "\\" + RIGHT_CURLY_BRACE},
-            {"" + RIGHT_SQUARE_BRACKET, "\\" + RIGHT_SQUARE_BRACKET}
-    };
+    static final Map<CharSequence, CharSequence> COMPACT_JSON_STRING_ESCAPE;
+
+    static {
+        Map<CharSequence, CharSequence> initialMap = new HashMap<>();
+        initialMap.put("\\", "\\\\");
+        initialMap.put("/", "\\/");
+        initialMap.put(Character.toString(COMMA), "\\" + COMMA);
+        initialMap.put(Character.toString(COLON), "\\" + COLON);
+        initialMap.put(Character.toString(RIGHT_CURLY_BRACE), "\\" + RIGHT_CURLY_BRACE);
+        initialMap.put(Character.toString(RIGHT_SQUARE_BRACKET), "\\" + RIGHT_SQUARE_BRACKET);
+        COMPACT_JSON_STRING_ESCAPE = unmodifiableMap(initialMap);
+    }
 
     static final CharSequenceTranslator ESCAPE_COMPACT_JSON =
             new AggregateTranslator(
                     new LookupTranslator(COMPACT_JSON_STRING_ESCAPE),
-                    new LookupTranslator(EntityArrays.JAVA_CTRL_CHARS_ESCAPE()),
+                    new LookupTranslator(EntityArrays.JAVA_CTRL_CHARS_ESCAPE),
                     JavaUnicodeEscaper.outsideOf(32, 0x7f));
 
     static final CharSequenceTranslator UNESCAPE_COMPACT_JSON =
             new AggregateTranslator(
                     new UnicodeUnescaper(),
-                    new LookupTranslator(EntityArrays.JAVA_CTRL_CHARS_UNESCAPE()),
-                    new LookupTranslator(EntityArrays.invert(COMPACT_JSON_STRING_ESCAPE)));
+                    new LookupTranslator(EntityArrays.JAVA_CTRL_CHARS_UNESCAPE),
+                    new LookupTranslator(EntityArrays.invert(COMPACT_JSON_STRING_ESCAPE))
+            );
 }

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/StringConverter.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/converter/StringConverter.java
@@ -30,8 +30,8 @@ import java.util.Objects;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeJava;
-import static org.apache.commons.lang3.StringEscapeUtils.unescapeJava;
+import static org.apache.commons.text.StringEscapeUtils.escapeJava;
+import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
 
 /**
  * This class converts {@link String} to/from string.

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/config/DefaultConfigurationValueProvider.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/config/DefaultConfigurationValueProvider.java
@@ -74,6 +74,7 @@ public class DefaultConfigurationValueProvider implements ConfigurationValueProv
         String resolvedValue = value.get();
         String val = applyProcessors(new ConfigurationValue(resolvedKey, resolvedValue, fromDefaultValue, metadata.getEncryptionProvider(), attributes));
 
+        @SuppressWarnings("unchecked")
         TypeConverter<T> currentTypeConverter = defaultIfNull((TypeConverter<T>) metadata.getTypeConverter(), typeConverter);
         return present(currentTypeConverter.fromString(metadata.getType(), val, attributes));
     }

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/factory/jdkproxy/JdkProxyDynamicConfigurationInstanceCreator.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/factory/jdkproxy/JdkProxyDynamicConfigurationInstanceCreator.java
@@ -45,6 +45,7 @@ public class JdkProxyDynamicConfigurationInstanceCreator implements Configuratio
         }
     }
 
+    @SuppressWarnings("unchecked")
     private <T> Class<T> generateClass(ConfigurationModel configurationModel, ClassLoader classLoader) {
         Class<?> configurationType = configurationModel.getConfigurationType();
         return (Class<T>) Proxy.getProxyClass(classLoader, configurationType, DynamicConfiguration.class);

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/model/provider/annotation/AnnotationMetadataExtractor.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/model/provider/annotation/AnnotationMetadataExtractor.java
@@ -194,6 +194,7 @@ public class AnnotationMetadataExtractor implements MetadataExtractor {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Class<TypeConverter<?>> getTypeConverter(Class<?> configurationType, Method method) {
         Converter converterAnnotation = findAnnotation(method, Converter.class);
         return converterAnnotation == null ? null : (Class<TypeConverter<?>>) converterAnnotation.value();
@@ -238,6 +239,7 @@ public class AnnotationMetadataExtractor implements MetadataExtractor {
             return emptyMap();
         }
         Class<?> defaultsAnnotation = findAnnotation(method.getReturnType(), DefaultsAnnotation.class).value();
+        @SuppressWarnings("unchecked")
         Annotation annotation = findAnnotation(method, (Class<? extends Annotation>) defaultsAnnotation);
         return getDefaultValues(annotation);
     }

--- a/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/utils/CachedAnnotationUtils.java
+++ b/conf4j-core/src/main/java/com/sabre/oss/conf4j/internal/utils/CachedAnnotationUtils.java
@@ -178,6 +178,7 @@ public final class CachedAnnotationUtils {
 
         private final ConcurrentMap<MultiKey, Object> cache = new ConcurrentHashMap<>();
 
+        @SuppressWarnings("unchecked")
         public V get(Supplier<? super V> supplier, Object... params) {
             MultiKey key = new MultiKey(params);
             Object value = cache.get(key);

--- a/conf4j-core/src/test/java/com/sabre/oss/conf4j/converter/JsonLikeConverterTest.java
+++ b/conf4j-core/src/test/java/com/sabre/oss/conf4j/converter/JsonLikeConverterTest.java
@@ -24,7 +24,7 @@
 
 package com.sabre.oss.conf4j.converter;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/model/provider/annotation/AnnotationConfigurationModelProviderTest.java
+++ b/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/model/provider/annotation/AnnotationConfigurationModelProviderTest.java
@@ -86,11 +86,13 @@ public class AnnotationConfigurationModelProviderTest {
         assertThat(allTimeoutsProperty.getDefaultValues()).isEmpty();
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends PropertyModel> T property(ConfigurationModel configurationModel, String property) {
         return configurationModel.getProperties().stream()
                 .filter(p -> p.getPropertyName().equals(property))
                 .map(p -> (T) p)
-                .findAny().get();
+                .findAny()
+                .get();
     }
 
     @Key("connection")

--- a/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/model/provider/annotation/AttributesExtractorTest.java
+++ b/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/model/provider/annotation/AttributesExtractorTest.java
@@ -26,8 +26,6 @@ package com.sabre.oss.conf4j.internal.model.provider.annotation;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.Meta;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Documented;
@@ -35,7 +33,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import static com.sabre.oss.conf4j.internal.model.provider.annotation.AttributesExtractor.getMetaAttributes;
 import static java.lang.annotation.ElementType.METHOD;
@@ -376,23 +373,5 @@ public class AttributesExtractorTest {
             throw new IllegalArgumentException("Class " + clazz.getName() + " doesn't declare parameterless method " + methodName);
         }
 
-    }
-
-    private static final class MatchesPattern extends TypeSafeMatcher<String> {
-        private final Pattern pattern;
-
-        private MatchesPattern(String pattern) {
-            this.pattern = Pattern.compile(pattern);
-        }
-
-        @Override
-        protected boolean matchesSafely(String item) {
-            return pattern.matcher(item).matches();
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("a string matching the pattern '" + pattern + '\'');
-        }
     }
 }

--- a/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/model/provider/convention/ConventionConfigurationModelProviderTest.java
+++ b/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/model/provider/convention/ConventionConfigurationModelProviderTest.java
@@ -245,6 +245,7 @@ public class ConventionConfigurationModelProviderTest {
         String getValue();
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends PropertyModel> T property(ConfigurationModel configurationModel, String property) {
         return configurationModel.getProperties().stream()
                 .filter(p -> p.getPropertyName().equals(property))

--- a/conf4j-extras/conf4j-extras-jaxb/src/main/java/com/sabre/oss/conf4j/jaxb/converter/JaxbConverter.java
+++ b/conf4j-extras/conf4j-extras-jaxb/src/main/java/com/sabre/oss/conf4j/jaxb/converter/JaxbConverter.java
@@ -70,6 +70,7 @@ public class JaxbConverter<T> implements TypeConverter<T> {
     private final ConcurrentMap<Class<T>, JaxbPool> jaxbPoolMap = new ConcurrentHashMap<>();
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean isApplicable(Type type, Map<String, String> attributes) {
         requireNonNull(type, "type cannot be null");
 
@@ -84,6 +85,7 @@ public class JaxbConverter<T> implements TypeConverter<T> {
             return null;
         }
 
+        @SuppressWarnings("unchecked")
         Class<T> targetClazz = (Class<T>) type;
         JaxbPool jaxbPool = getJaxbPool(targetClazz);
         try (Handle<Unmarshaller> handle = jaxbPool.borrowUnmarshaller()) {
@@ -101,6 +103,7 @@ public class JaxbConverter<T> implements TypeConverter<T> {
             return null;
         }
 
+        @SuppressWarnings("unchecked")
         JaxbPool jaxbPool = getJaxbPool((Class<T>) type);
         try (Handle<Marshaller> handle = jaxbPool.borrowMarshaller()) {
             Marshaller marshaller = handle.get();
@@ -148,7 +151,6 @@ public class JaxbConverter<T> implements TypeConverter<T> {
          *
          * @param clazz class to read schema
          * @return XSD schema or null
-         * @throws SAXException
          */
         Schema readXsdSchema(Class<?> clazz) throws SAXException {
             XmlSchema xmlSchema = clazz.getPackage().getAnnotation(XmlSchema.class);

--- a/conf4j-extras/conf4j-extras-json/src/main/java/com/sabre/oss/conf4j/json/converter/JsonConverter.java
+++ b/conf4j-extras/conf4j-extras-json/src/main/java/com/sabre/oss/conf4j/json/converter/JsonConverter.java
@@ -89,6 +89,7 @@ public class JsonConverter<T> implements TypeConverter<T> {
         }
 
         try {
+            @SuppressWarnings("unchecked")
             ObjectReader objectReader = objectMapper.readerFor((Class<T>) type);
             return objectReader.readValue(value);
         } catch (IOException e) {

--- a/conf4j-extras/conf4j-extras-yaml/src/main/java/com/sabre/oss/conf4j/yaml/converter/YamlConverter.java
+++ b/conf4j-extras/conf4j-extras-yaml/src/main/java/com/sabre/oss/conf4j/yaml/converter/YamlConverter.java
@@ -74,6 +74,7 @@ public class YamlConverter<T> implements TypeConverter<T> {
         return ignoreConverterAttribute || Objects.equals(converter, YAML);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public T fromString(Type type, String value, Map<String, String> attributes) {
         requireNonNull(type, "type cannot be null");

--- a/conf4j-javassist/pom.xml
+++ b/conf4j-javassist/pom.xml
@@ -79,10 +79,6 @@
             <artifactId>apiguardian-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/conf4j-javassist/src/main/java/com/sabre/oss/conf4j/internal/factory/javassist/CodeBuilder.java
+++ b/conf4j-javassist/src/main/java/com/sabre/oss/conf4j/internal/factory/javassist/CodeBuilder.java
@@ -24,7 +24,7 @@
 
 package com.sabre.oss.conf4j.internal.factory.javassist;
 
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StrSubstitutor;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/conf4j-javassist/src/main/java/com/sabre/oss/conf4j/internal/factory/javassist/JavassistDynamicConfigurationInstanceCreator.java
+++ b/conf4j-javassist/src/main/java/com/sabre/oss/conf4j/internal/factory/javassist/JavassistDynamicConfigurationInstanceCreator.java
@@ -56,6 +56,7 @@ public class JavassistDynamicConfigurationInstanceCreator extends AbstractJavass
         /*
          * Used by javassist. Do not remove.
          */
+        @SuppressWarnings("unchecked")
         public static OptionalValue<Object> getConfigurationValue(Object configuration, PropertyMetadata metadata) {
             DynamicConfiguration dynamicConfiguration = (DynamicConfiguration) configuration;
             ConfigurationSource configurationSource = dynamicConfiguration.getConfigurationSource();

--- a/conf4j-spring/pom.xml
+++ b/conf4j-spring/pom.xml
@@ -108,10 +108,6 @@
             <artifactId>apiguardian-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
@@ -122,10 +118,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.kubek2k</groupId>
-            <artifactId>springockito</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/annotation/ConfigurationScanRegistrar.java
+++ b/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/annotation/ConfigurationScanRegistrar.java
@@ -98,6 +98,7 @@ class ConfigurationScanRegistrar implements ImportBeanDefinitionRegistrar, Envir
         return packagesToScan.isEmpty() ? singleton(getPackageName(metadata.getClassName())) : packagesToScan;
     }
 
+    @SuppressWarnings("unchecked")
     private Set<Class<? extends Annotation>> getConfigurationAnnotationClasses(AnnotationMetadata metadata) {
         AnnotationAttributes attributes = AnnotationAttributes.fromMap(metadata.getAnnotationAttributes(ConfigurationScan.class.getName()));
         Class<?>[] configurationAnnotations = attributes.getClassArray("configurationAnnotations");

--- a/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/converter/CachingTypeConverter.java
+++ b/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/converter/CachingTypeConverter.java
@@ -174,6 +174,7 @@ public class CachingTypeConverter<T> implements TypeConverter<T>, InitializingBe
      * @throws IllegalArgumentException when {@code value} cannot be converted to {@code T}.
      * @throws NullPointerException     when {@code type} is {@code null}.
      */
+    @SuppressWarnings("unchecked")
     @Override
     public T fromString(Type type, String value, Map<String, String> attributes) {
         requireNonNull(type, "type cannot be null");

--- a/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/handler/ConfigurationScanBeanDefinitionParser.java
+++ b/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/handler/ConfigurationScanBeanDefinitionParser.java
@@ -79,6 +79,7 @@ public class ConfigurationScanBeanDefinitionParser extends ComponentScanBeanDefi
         return configurationAnnotationClasses;
     }
 
+    @SuppressWarnings("unchecked")
     private Class<? extends Annotation> getAnnotationClasses(String className, ClassLoader classLoader) {
         Class<?> clazz;
         try {

--- a/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/internal/factory/cglib/CglibStaticConfigurationInstanceCreator.java
+++ b/conf4j-spring/src/main/java/com/sabre/oss/conf4j/spring/internal/factory/cglib/CglibStaticConfigurationInstanceCreator.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
 
 public class CglibStaticConfigurationInstanceCreator implements ConfigurationInstanceCreator {
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T createInstance(ConfigurationModel configurationModel, ClassLoader classLoader) {
         Class<?> configurationType = configurationModel.getConfigurationType();
 

--- a/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConverterDecoratorsAnnotationsBasedTest.java
+++ b/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConverterDecoratorsAnnotationsBasedTest.java
@@ -47,6 +47,7 @@ public class AutodiscoverConverterDecoratorsAnnotationsBasedTest extends Abstrac
         AggregatedConverter converter = applicationContext.getBean(AggregatedConverter.class);
 
         assertThat(converter).isNotNull();
+        @SuppressWarnings("unchecked")
         List<DecoratingConverterFactory> autowired =
                 (List<DecoratingConverterFactory>) getField(converter, "autowiredFactories");
 

--- a/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConverterDecoratorsFromCustomNamespaceTest.java
+++ b/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConverterDecoratorsFromCustomNamespaceTest.java
@@ -45,6 +45,7 @@ public class AutodiscoverConverterDecoratorsFromCustomNamespaceTest extends Abst
         AggregatedConverter converter = applicationContext.getBean(AggregatedConverter.class);
 
         assertThat(converter).isNotNull();
+        @SuppressWarnings("unchecked")
         List<DecoratingConverterFactory> autowired =
                 (List<DecoratingConverterFactory>) getField(converter, "autowiredFactories");
 

--- a/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConvertersAnnotationsBasedTest.java
+++ b/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConvertersAnnotationsBasedTest.java
@@ -45,6 +45,7 @@ import static org.springframework.test.util.ReflectionTestUtils.getField;
 @EnableConf4j
 public class AutodiscoverConvertersAnnotationsBasedTest extends AbstractContextTest {
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldAutodiscoverAllConvertersRegisteredInContext() {
         isRegistered(AggregatedConverter.class, CONF4J_TYPE_CONVERTER);
         AggregatedConverter converter = applicationContext.getBean(AggregatedConverter.class);

--- a/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConvertersFromCustomNamespaceTest.java
+++ b/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/AutodiscoverConvertersFromCustomNamespaceTest.java
@@ -48,6 +48,7 @@ public class AutodiscoverConvertersFromCustomNamespaceTest extends AbstractConte
         AggregatedConverter converter = applicationContext.getBean(AggregatedConverter.class);
 
         assertThat(converter).isNotNull();
+        @SuppressWarnings("unchecked")
         List<TypeConverter<?>> autowired = (List<TypeConverter<?>>) getField(converter, "autowired");
 
         assertThat(autowired)

--- a/conf4j-spring/src/test/resources/SpringConfigurationFactoryTest/conf4j.spring.test.xml
+++ b/conf4j-spring/src/test/resources/SpringConfigurationFactoryTest/conf4j.spring.test.xml
@@ -25,9 +25,9 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:conf4j="http://www.sabre.com/schema/oss/conf4j" xmlns:mockito="http://www.mockito.org/spring/mockito"
+       xmlns:conf4j="http://www.sabre.com/schema/oss/conf4j"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.sabre.com/schema/oss/conf4j http://www.sabre.com/schema/oss/conf4j/conf4j.xsd http://www.mockito.org/spring/mockito http://www.mockito.org/spring/mockito.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.sabre.com/schema/oss/conf4j http://www.sabre.com/schema/oss/conf4j/conf4j.xsd   http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
        default-lazy-init="true">
 
     <conf4j:configure/>
@@ -37,9 +37,5 @@
     <context:property-placeholder location="classpath:SpringConfigurationFactoryTest/conf4j.test.properties"/>
 
     <bean class="com.sabre.oss.conf4j.spring.model.SpringBean"/>
-
-    <!-- Test specific extensions -->
-    <mockito:spy beanName="com.sabre.oss.conf4j.configurationSource"/>
-    <mockito:spy beanName="com.sabre.oss.conf4j.typeConverter"/>
 
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jackson.version>2.9.3</jackson.version>
-        <spring.boot.version>1.5.8.RELEASE</spring.boot.version>
-        <spring.version>4.3.9.RELEASE</spring.version>
+        <jackson.version>2.8.10</jackson.version>
+        <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
+        <spring.version>4.3.14.RELEASE</spring.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j.version>2.8.2</log4j.version>
+        <log4j.version>2.10.0</log4j.version>
         <junit-jupiter.version>5.0.2</junit-jupiter.version>
         <junit-platform.version>1.0.2</junit-platform.version>
     </properties>
@@ -124,7 +124,13 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.5</version>
+                <version>3.7</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.2</version>
             </dependency>
 
             <dependency>
@@ -231,16 +237,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.12.0</version>
+                <version>2.15.0</version>
                 <scope>test</scope>
             </dependency>
 
@@ -254,21 +253,21 @@
             <dependency>
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
-                <version>1.19</version>
+                <version>1.20</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-generator-annprocess</artifactId>
-                <version>1.19</version>
+                <version>1.20</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.3.0</version>
+                <version>3.9.0</version>
                 <scope>test</scope>
             </dependency>
 
@@ -297,13 +296,6 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-jcl</artifactId>
                 <version>${log4j.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.kubek2k</groupId>
-                <artifactId>springockito</artifactId>
-                <version>1.0.9</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Spring and Spring Boot is upgraded to the version compatible
with Spring IO Platform Brussels-SR7.

commons-lang is upgraded to 3.7 and because many classes from text
package are deprecated, added dependency to commons-text.

Remove dependency to hamcrest and springockito.