### PR TITLE
Support for JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ sudo: false
 script: chmod +x ./.travis/build.sh && ./.travis/build.sh
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+- oraclejdk8
+- oraclejdk9
+- oraclejdk10
+- oraclejdk11

--- a/conf4j-core/pom.xml
+++ b/conf4j-core/pom.xml
@@ -24,7 +24,8 @@
   SOFTWARE.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -112,8 +113,8 @@
         </dependency>
 
         <dependency>
-            <groupId>name.falgout.jeffrey.testing.junit5</groupId>
-            <artifactId>mockito-extension</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/config/DefaultConfigurationValueProviderTest.java
+++ b/conf4j-core/src/test/java/com/sabre/oss/conf4j/internal/config/DefaultConfigurationValueProviderTest.java
@@ -31,12 +31,13 @@ import com.sabre.oss.conf4j.processor.ConfigurationValue;
 import com.sabre.oss.conf4j.processor.ConfigurationValueProcessor;
 import com.sabre.oss.conf4j.source.OptionalValue;
 import com.sabre.oss.conf4j.source.TestConfigurationSource;
-import name.falgout.jeffrey.testing.junit5.MockitoExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
@@ -120,7 +121,7 @@ public class DefaultConfigurationValueProviderTest {
     @Test
     public void shouldReturnFromFallbackKeyPrefix() {
         // given
-        when(source.getValue("fallbackKeyPrefix.key", null)).thenReturn(present("value"));
+        Mockito.lenient().when(source.getValue("fallbackKeyPrefix.key", null)).thenReturn(present("value"));
 
         // when
         OptionalValue<String> result = provider.getConfigurationValue(typeConverter, source, metadata(getKeySet(), defaultValue, notEncrypted));
@@ -132,7 +133,7 @@ public class DefaultConfigurationValueProviderTest {
     @Test
     public void shouldNotReturnFallbackKeyPrefixValueWhenFallbackKeyPrefixIsEmpty() {
         // given
-        when(source.getValue(".key", null)).thenReturn(present("value"));
+        Mockito.lenient().when(source.getValue(".key", null)).thenReturn(present("value"));
         fallbackKeyPrefixGenerator = emptyKeyGenerator();
 
         // when
@@ -157,7 +158,7 @@ public class DefaultConfigurationValueProviderTest {
     @Test
     public void shouldNotReturnFallbackKeyValueWhenFallbackKeyIsEmpty() {
         // given
-        when(source.getValue("", null)).thenReturn(present("value"));
+        Mockito.lenient().when(source.getValue("", null)).thenReturn(present("value"));
         fallbackKey = null;
 
         // when

--- a/conf4j-javassist/src/main/java/com/sabre/oss/conf4j/internal/factory/javassist/AbstractJavassistConfigurationInstanceCreator.java
+++ b/conf4j-javassist/src/main/java/com/sabre/oss/conf4j/internal/factory/javassist/AbstractJavassistConfigurationInstanceCreator.java
@@ -164,7 +164,7 @@ abstract class AbstractJavassistConfigurationInstanceCreator implements Configur
         @SuppressWarnings("unchecked")
         protected <T> Class<T> generateClass(ClassLoader classLoader) {
             try {
-                return ctClass.toClass(classLoader, getClass().getProtectionDomain());
+                return (Class<T>) ctClass.toClass(classLoader, getClass().getProtectionDomain());
             } catch (CannotCompileException e) {
                 throw new RuntimeException(e);
             }

--- a/conf4j-spring/pom.xml
+++ b/conf4j-spring/pom.xml
@@ -24,7 +24,8 @@
   SOFTWARE.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -137,8 +138,8 @@
         </dependency>
 
         <dependency>
-            <groupId>name.falgout.jeffrey.testing.junit5</groupId>
-            <artifactId>mockito-extension</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -163,6 +164,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/CachingTypeConverterTest.java
+++ b/conf4j-spring/src/test/java/com/sabre/oss/conf4j/spring/converter/CachingTypeConverterTest.java
@@ -31,11 +31,12 @@ import com.sabre.oss.conf4j.converter.TypeConverter;
 import com.sabre.oss.conf4j.spring.Conf4jSpringConstants;
 import com.sabre.oss.conf4j.spring.annotation.ConfigurationType;
 import com.sabre.oss.conf4j.spring.annotation.EnableConf4j;
-import name.falgout.jeffrey.testing.junit5.MockitoExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -60,7 +61,7 @@ public class CachingTypeConverterTest {
 
     @BeforeEach
     public void setUp() {
-        when(mockCacheManager.getCache("cacheRegion")).thenReturn(mockCache);
+        Mockito.lenient().when(mockCacheManager.getCache("cacheRegion")).thenReturn(mockCache);
         converter.setTypeConverter(mockConverter);
         converter.setCacheName("cacheRegion");
         converter.setCacheManager(mockCacheManager);
@@ -68,7 +69,7 @@ public class CachingTypeConverterTest {
 
     @Test
     public void shouldDelegateToIsApplicableWithoutCaching() {
-        when(mockConverter.isApplicable(Long.class, null)).thenReturn(true);
+        Mockito.lenient().when(mockConverter.isApplicable(Long.class, null)).thenReturn(true);
         when(mockConverter.isApplicable(Object.class, null)).thenReturn(false);
 
         converter.afterPropertiesSet();
@@ -85,7 +86,7 @@ public class CachingTypeConverterTest {
     @Test
     public void shouldDelegateToToStringToWithoutCaching() {
 
-        when(mockConverter.toString(Long.class, 10L, null)).thenReturn("10");
+        Mockito.lenient().when(mockConverter.toString(Long.class, 10L, null)).thenReturn("10");
         when(mockConverter.toString(Long.class, 20L, null)).thenReturn("20");
 
         converter.afterPropertiesSet();
@@ -104,7 +105,7 @@ public class CachingTypeConverterTest {
         converter.setCacheManager(new ConcurrentMapCacheManager());
 
 
-        when(mockConverter.fromString(Long.class, "10", null)).thenReturn(10L);
+        Mockito.lenient().when(mockConverter.fromString(Long.class, "10", null)).thenReturn(10L);
         when(mockConverter.fromString(Long.class, "20", null)).thenReturn(20L);
 
         converter.afterPropertiesSet();

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
   SOFTWARE.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.sabre.oss.conf4j</groupId>
@@ -122,7 +123,7 @@
         <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
         <spring.version>4.3.14.RELEASE</spring.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j.version>2.10.0</log4j.version>
+        <log4j.version>2.8.1</log4j.version>
         <junit-jupiter.version>5.1.0</junit-jupiter.version>
         <junit-platform.version>1.1.0</junit-platform.version>
     </properties>
@@ -150,7 +151,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.22.0-GA</version>
+                <version>3.23.1-GA</version>
             </dependency>
 
             <dependency>
@@ -175,6 +176,12 @@
                 <groupId>javax.activation</groupId>
                 <artifactId>javax.activation-api</artifactId>
                 <version>1.2.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
             </dependency>
 
             <dependency>
@@ -271,13 +278,13 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.15.0</version>
+                <version>2.23.0</version>
             </dependency>
 
             <dependency>
-                <groupId>name.falgout.jeffrey.testing.junit5</groupId>
-                <artifactId>mockito-extension</artifactId>
-                <version>1.0.0</version>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>2.23.0</version>
             </dependency>
 
             <dependency>
@@ -353,8 +360,8 @@
                             <phase>validate</phase>
                             <configuration>
                                 <rules>
-                                    <dependencyConvergence />
-                                    <reactorModuleConvergence />
+                                    <dependencyConvergence/>
+                                    <reactorModuleConvergence/>
                                     <requireMavenVersion>
                                         <version>3.3.3</version>
                                     </requireMavenVersion>
@@ -401,7 +408,7 @@
 
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
- **Downgrade log4j**: Springboot 1.5.x supports log4j up to version 2.8.1. Up to this point we were getting NoSuchMethodError in tests.
- **Changed Mockito JUnit plugin**: changed plugin for the official Mockito one. It supports Java 11.
- **Upgrade Mockito**: current version doesn't support Java 11. New version requires Mockito.lenient() when using unecessary stubbings. Otherwise it fails tests.
- **Add dependency to javax.annotation**: it is not a part of JDK anymore.
- **Upgrade Javassist**
- **Upgrade JavaDoc plugin**
- **Enable Oracle JDK 11 Travis build**